### PR TITLE
feat: added input shared component

### DIFF
--- a/src/components/ui/input/__test__/input.test.tsx
+++ b/src/components/ui/input/__test__/input.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Input from '..';
+
+const mock_props = {
+    onChange: vi.fn(),
+    value: 'test',
+};
+describe('Dialog', () => {
+    it('should render the Input component', () => {
+        render(<Input {...mock_props} />);
+        expect(screen.getByDisplayValue('test')).toBeInTheDocument();
+    });
+    it('should render the hint', () => {
+        render(<Input {...mock_props} hint='hint test value' />);
+        expect(screen.getByText('hint test value')).toBeInTheDocument();
+    });
+    it('should render the leading icon', () => {
+        render(<Input {...mock_props} leadingIcon={<img src='/images/leading_image.svg' />} />);
+        const image = screen.getByRole('img');
+        expect(image).toBeInTheDocument();
+        expect(image).toHaveAttribute('src', '/images/leading_image.svg');
+        expect(image).toHaveClass('absolute left-4');
+    });
+    it('should render the trailing icon', () => {
+        render(<Input {...mock_props} trailingIcon={<img src='/images/trailing_image.svg' />} />);
+        const image = screen.getByRole('img');
+        expect(image).toBeInTheDocument();
+        expect(image).toHaveAttribute('src', '/images/trailing_image.svg');
+        expect(image).toHaveClass('absolute right-4');
+    });
+    it('should render the label', () => {
+        render(<Input {...mock_props} label='label test value' />);
+        const label = screen.getByText('label test value');
+        expect(label).toBeInTheDocument();
+    });
+});

--- a/src/components/ui/input/__test__/input.test.tsx
+++ b/src/components/ui/input/__test__/input.test.tsx
@@ -7,7 +7,7 @@ const mock_props = {
     onChange: vi.fn(),
     value: 'test',
 };
-describe('Dialog', () => {
+describe('Input', () => {
     it('should render the Input component', () => {
         render(<Input {...mock_props} />);
         expect(screen.getByDisplayValue('test')).toBeInTheDocument();

--- a/src/components/ui/input/__test__/input.test.tsx
+++ b/src/components/ui/input/__test__/input.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import Input from '..';

--- a/src/components/ui/input/index.tsx
+++ b/src/components/ui/input/index.tsx
@@ -46,50 +46,48 @@ const Input = forwardRef<HTMLInputElement, TInputProps>(
         ref
     ) => {
         return (
-            <div className='my-3 flex flex-col px-2'>
-                <div className='flex w-full flex-row items-center gap-2'>
-                    {labelAlignment === 'left' && <Label id={id} label={label} className={labelClassname} />}
-                    <div className='relative flex w-full items-center'>
-                        {leadingIcon &&
-                            cloneElement(leadingIcon, {
-                                className: cn(
-                                    'absolute left-4 ',
-                                    { 'opacity-50': props.disabled },
-                                    leadingIcon.props.className
-                                ),
-                            })}
-                        <input
-                            type={type}
-                            className={cn(
-                                'my-1 w-full rounded-[5px] border px-2 py-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
-                                { 'border-danger text-danger': error },
-                                className
-                            )}
-                            ref={ref}
-                            {...props}
-                        />
-                        {trailingIcon &&
-                            cloneElement(trailingIcon, {
-                                className: cn(
-                                    'absolute right-4',
-                                    { 'opacity-50': props.disabled },
-                                    trailingIcon.props.className
-                                ),
-                            })}
-                        {hint && (
-                            <span
-                                className={cn(
-                                    'absolute bottom-[-1rem] text-[0.75rem]',
-                                    { 'italic text-danger': error },
-                                    hintClassname
-                                )}
-                            >
-                                {hint}
-                            </span>
+            <div className='my-3 flex w-full flex-row items-center gap-2 px-2'>
+                {labelAlignment === 'left' && <Label id={id} label={label} className={labelClassname} />}
+                <div className='relative flex w-full items-center'>
+                    {leadingIcon &&
+                        cloneElement(leadingIcon, {
+                            className: cn(
+                                'absolute left-4 ',
+                                { 'opacity-50': props.disabled },
+                                leadingIcon.props.className
+                            ),
+                        })}
+                    <input
+                        type={type}
+                        className={cn(
+                            'my-1 w-full rounded-[5px] border px-2 py-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+                            { 'border-danger text-danger': error },
+                            className
                         )}
-                    </div>
-                    {labelAlignment === 'right' && <Label id={id} label={label} className={labelClassname} />}
+                        ref={ref}
+                        {...props}
+                    />
+                    {trailingIcon &&
+                        cloneElement(trailingIcon, {
+                            className: cn(
+                                'absolute right-4',
+                                { 'opacity-50': props.disabled },
+                                trailingIcon.props.className
+                            ),
+                        })}
+                    {hint && (
+                        <span
+                            className={cn(
+                                'absolute bottom-[-1rem] text-[0.75rem]',
+                                { 'italic text-danger': error },
+                                hintClassname
+                            )}
+                        >
+                            {hint}
+                        </span>
+                    )}
                 </div>
+                {labelAlignment === 'right' && <Label id={id} label={label} className={labelClassname} />}
             </div>
         );
     }

--- a/src/components/ui/input/index.tsx
+++ b/src/components/ui/input/index.tsx
@@ -1,0 +1,100 @@
+import { cloneElement, forwardRef, InputHTMLAttributes, ReactElement } from 'react';
+
+import { cn } from 'Utils/cn';
+
+export interface TInputProps extends InputHTMLAttributes<HTMLInputElement> {
+    error?: boolean;
+    hint?: string;
+    hintClassname?: string;
+    label?: string;
+    labelAlignment?: 'left' | 'right';
+    labelClassname?: string;
+    leadingIcon?: ReactElement;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    trailingIcon?: ReactElement;
+    value: string;
+}
+
+type TLabelProps = {
+    className?: string;
+    id?: string;
+    label: string;
+};
+
+const Label = ({ className, id, label }: TLabelProps) => (
+    <label htmlFor={id} className={cn('whitespace-nowrap', className)}>
+        {label}
+    </label>
+);
+
+const Input = forwardRef<HTMLInputElement, TInputProps>(
+    (
+        {
+            className,
+            hintClassname = '',
+            id,
+            error = false,
+            hint = '',
+            label = '',
+            labelAlignment = 'left',
+            labelClassname = '',
+            leadingIcon,
+            trailingIcon,
+            type,
+            ...props
+        },
+        ref
+    ) => {
+        return (
+            <div className='my-3 flex flex-col px-2'>
+                <div className='flex w-full flex-row items-center gap-2'>
+                    {labelAlignment === 'left' && <Label id={id} label={label} className={labelClassname} />}
+                    <div className='relative flex w-full items-center'>
+                        {leadingIcon &&
+                            cloneElement(leadingIcon, {
+                                className: cn(
+                                    'absolute left-4 ',
+                                    { 'opacity-50': props.disabled },
+                                    leadingIcon.props.className
+                                ),
+                            })}
+                        <input
+                            type={type}
+                            className={cn(
+                                'my-1 w-full rounded-[5px] border px-2 py-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+                                { 'border-danger text-danger': error },
+                                className
+                            )}
+                            ref={ref}
+                            {...props}
+                        />
+                        {trailingIcon &&
+                            cloneElement(trailingIcon, {
+                                className: cn(
+                                    'absolute right-4',
+                                    { 'opacity-50': props.disabled },
+                                    trailingIcon.props.className
+                                ),
+                            })}
+                        {hint && (
+                            <span
+                                className={cn(
+                                    'absolute bottom-[-1rem] text-[0.75rem]',
+                                    { 'italic text-danger': error },
+                                    hintClassname
+                                )}
+                            >
+                                {hint}
+                            </span>
+                        )}
+                    </div>
+                    {labelAlignment === 'right' && <Label id={id} label={label} className={labelClassname} />}
+                </div>
+            </div>
+        );
+    }
+);
+
+Input.displayName = 'Input';
+
+export default Input;

--- a/stories/Input.stories.ts
+++ b/stories/Input.stories.ts
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Input from 'Components/ui/input';
+
+const meta = {
+    title: 'Input',
+    component: Input,
+    tags: ['autodocs'],
+    argTypes: {
+        value: {
+            control: {
+                type: 'text',
+            },
+        },
+        placeholder: {
+            control: {
+                type: 'text',
+            },
+        },
+    },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type TInputStory = StoryObj<typeof meta>;
+
+export const Primary: TInputStory = {
+    args: {
+        value: 'test',
+        placeholder: 'placeholder',
+    },
+};


### PR DESCRIPTION
Shared component for input field
<img width="1235" alt="Screenshot 2023-11-02 at 4 23 35 PM" src="https://github.com/deriv-com/smarttrader/assets/122768621/8b3c384d-7d1a-40ef-9cc6-3583444499bd">
<img width="403" alt="Screenshot 2023-11-02 at 4 23 50 PM" src="https://github.com/deriv-com/smarttrader/assets/122768621/f26fc9a7-aaba-41d9-a729-e0c45b548057">
![Screenshot 2023-11-02 at 4 27 45 PM](https://github.com/deriv-com/smarttrader/assets/122768621/76db8a32-aacc-4fce-adbc-2f6cdecbc0ff)
![Screenshot 2023-11-02 at 4 28 12 PM](https://github.com/deriv-com/smarttrader/assets/122768621/0435ff56-e04d-48e7-b86d-f9ffc96d5fad)
![Screenshot 2023-11-02 at 4 30 52 PM](https://github.com/deriv-com/smarttrader/assets/122768621/96f9b608-5c69-41ac-a82f-87bc939879ab)
![Screenshot 2023-11-02 at 4 40 48 PM](https://github.com/deriv-com/smarttrader/assets/122768621/1c33fd1b-6fda-4a9d-a19c-c774e40fd088)
