### PR TITLE
fix: refactor dialog component to include default export, add storybook

### DIFF
--- a/src/components/ui/dialog/Dialog.tsx
+++ b/src/components/ui/dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, ElementRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react';
+import { ComponentPropsWithoutRef, ElementRef, forwardRef, HTMLAttributes, PropsWithChildren, ReactNode } from 'react';
 import { Close, Content, Description, Overlay, Portal, Root, Title, Trigger } from '@radix-ui/react-dialog';
 import { Cross1Icon as CloseIcon } from '@radix-ui/react-icons';
 import { cn } from 'Utils/cn';
@@ -68,9 +68,9 @@ const DialogDescription = forwardRef<ElementRef<typeof Description>, ComponentPr
 DialogDescription.displayName = Description.displayName;
 
 type TDialogProps = {
-    trigger: React.ReactNode;
-    title?: string | React.ReactNode;
-    footer?: React.ReactNode;
+    trigger: ReactNode;
+    title?: string | ReactNode;
+    footer?: ReactNode;
 };
 const Dialog = ({ trigger, title = '', children, footer = null, ...props }: PropsWithChildren<TDialogProps>) => {
     return (

--- a/src/components/ui/dialog/Dialog.tsx
+++ b/src/components/ui/dialog/Dialog.tsx
@@ -1,12 +1,10 @@
-import { ComponentPropsWithoutRef, ElementRef, forwardRef, HTMLAttributes } from 'react';
+import { ComponentPropsWithoutRef, ElementRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react';
 import { Close, Content, Description, Overlay, Portal, Root, Title, Trigger } from '@radix-ui/react-dialog';
 import { Cross1Icon as CloseIcon } from '@radix-ui/react-icons';
 import { cn } from 'Utils/cn';
 
-const Dialog = Root;
 const DialogTrigger = Trigger;
 const DialogPortal = Portal;
-const DialogClose = Close;
 
 const DialogOverlay = forwardRef<ElementRef<typeof Overlay>, ComponentPropsWithoutRef<typeof Overlay>>(
     ({ className, ...props }, ref) => (
@@ -69,15 +67,24 @@ const DialogDescription = forwardRef<ElementRef<typeof Description>, ComponentPr
 );
 DialogDescription.displayName = Description.displayName;
 
-export {
-    Dialog,
-    DialogPortal,
-    DialogOverlay,
-    DialogClose,
-    DialogTrigger,
-    DialogContent,
-    DialogHeader,
-    DialogFooter,
-    DialogTitle,
-    DialogDescription,
+type TDialogProps = {
+    trigger: React.ReactNode;
+    title?: string | React.ReactNode;
+    footer?: React.ReactNode;
 };
+const Dialog = ({ trigger, title = '', children, footer = null, ...props }: PropsWithChildren<TDialogProps>) => {
+    return (
+        <Root>
+            <DialogTrigger>{trigger}</DialogTrigger>
+            <DialogContent>
+                <DialogHeader>
+                    {title && <DialogTitle>{title}</DialogTitle>}
+                    <DialogDescription {...props}>{children}</DialogDescription>
+                </DialogHeader>
+                {footer && <DialogFooter>{footer}</DialogFooter>}
+            </DialogContent>
+        </Root>
+    );
+};
+
+export default Dialog;

--- a/src/components/ui/dialog/__test__/dialog.test.tsx
+++ b/src/components/ui/dialog/__test__/dialog.test.tsx
@@ -1,105 +1,44 @@
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
-} from '../index';
+import Dialog from '../Dialog';
+
+const mock_props = {
+    title: 'mock title',
+    footer: <div>i am the footer content</div>,
+    trigger: <div>Trigger</div>,
+};
 
 describe('Dialog', () => {
+    const renderComponent = () => render(<Dialog {...mock_props}>This is the mock content</Dialog>);
     it('should render the Dialog component', () => {
-        render(<Dialog>Dialog</Dialog>);
-        const dialogElement = screen.getByText('Dialog');
+        renderComponent();
+        const dialogElement = screen.getByText('Trigger');
         expect(dialogElement).toBeInTheDocument();
     });
     it('should open the dialog modal when the trigger is clicked', async () => {
-        render(
-            <Dialog>
-                <DialogTrigger>Trigger</DialogTrigger>
-                <DialogContent>Content</DialogContent>
-            </Dialog>
-        );
+        renderComponent();
         const triggerElement = screen.getByText('Trigger');
         await userEvent.click(triggerElement);
-        expect(screen.getByText('Content')).toBeInTheDocument();
+        expect(screen.getByText('This is the mock content')).toBeInTheDocument();
     });
     it('should render the Header inside the Dialog', async () => {
-        render(
-            <Dialog>
-                <DialogTrigger>Trigger</DialogTrigger>
-                <DialogContent>
-                    <DialogHeader>Header</DialogHeader>
-                </DialogContent>
-            </Dialog>
-        );
+        renderComponent();
         await userEvent.click(screen.getByText('Trigger'));
-        const headerElement = screen.getByText('Header');
+        const headerElement = screen.getByText('mock title');
         expect(headerElement).toBeInTheDocument();
     });
     it('should display the Footer inside the Dialog', async () => {
-        render(
-            <Dialog>
-                <DialogTrigger>Trigger</DialogTrigger>
-                <DialogContent>
-                    <DialogHeader>Header</DialogHeader>
-                    <DialogFooter>Footer</DialogFooter>
-                </DialogContent>
-            </Dialog>
-        );
+        renderComponent();
         await userEvent.click(screen.getByText('Trigger'));
-        expect(screen.getByText('Footer')).toBeInTheDocument();
+        expect(screen.getByText('i am the footer content')).toBeInTheDocument();
     });
-    it('should render the Dialog Title', async () => {
-        render(
-            <Dialog>
-                <DialogTrigger>Trigger</DialogTrigger>
-                <DialogContent>
-                    <DialogHeader>
-                        <DialogTitle>Title</DialogTitle>
-                    </DialogHeader>
-                </DialogContent>
-            </Dialog>
-        );
-        await userEvent.click(screen.getByText('Trigger'));
-        expect(screen.getByText('Title')).toBeInTheDocument();
-    });
-    it('should render the Dialog description', async () => {
-        render(
-            <Dialog>
-                <DialogTrigger>Trigger</DialogTrigger>
-                <DialogContent>
-                    <DialogHeader>
-                        <DialogTitle>Title</DialogTitle>
-                        <DialogDescription>Description</DialogDescription>
-                    </DialogHeader>
-                </DialogContent>
-            </Dialog>
-        );
-
-        await userEvent.click(screen.getByText('Trigger'));
-        expect(screen.getByText('Description')).toBeInTheDocument();
-    });
-    it('should close the Dialog button on clicking close', async () => {
-        render(
-            <Dialog>
-                <DialogTrigger>Trigger</DialogTrigger>
-                <DialogContent>
-                    <DialogHeader>
-                        <DialogTitle>Title</DialogTitle>
-                        <DialogDescription>Description</DialogDescription>
-                    </DialogHeader>
-                </DialogContent>
-            </Dialog>
-        );
+    it('should close the modal on clicking close', async () => {
+        renderComponent();
         await userEvent.click(screen.getByText('Trigger'));
         const close = screen.getByRole('button', { name: 'Close' });
         expect(close).toBeInTheDocument();
         await userEvent.click(close);
-        expect(screen.queryByText('Description')).not.toBeInTheDocument();
+        expect(screen.queryByText('This is the mock content')).not.toBeInTheDocument();
     });
 });

--- a/src/components/ui/dialog/index.ts
+++ b/src/components/ui/dialog/index.ts
@@ -1,0 +1,3 @@
+import Dialog from './Dialog';
+
+export default Dialog;

--- a/stories/Dialog.stories.ts
+++ b/stories/Dialog.stories.ts
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Dialog from 'Components/ui/dialog';
+
+const meta = {
+    title: 'Dialog',
+    component: Dialog,
+    tags: ['autodocs'],
+} satisfies Meta<typeof Dialog>;
+
+export default meta;
+type TDailogStory = StoryObj<typeof meta>;
+
+export const Primary: TDailogStory = {
+    args: {
+        children: 'test',
+        title: 'title',
+        footer: 'footer',
+        trigger: 'trigger',
+    },
+};


### PR DESCRIPTION
Refactored to dialog component to remove shadcn ui and include default export, also added storybook